### PR TITLE
fix ro test and also produce output results file

### DIFF
--- a/registerTest.py
+++ b/registerTest.py
@@ -15,7 +15,7 @@ from registerTest_setDefaults import registerTest_setDefaults_igloo
 from registerTest_setDefaults import registerTest_setDefaults_qie
 from registerTest_ro import registerTest_ro_bridge
 from registerTest_ro import registerTest_ro_igloo
-from registerTest_ro import registerTest_ro_qie
+#from registerTest_ro import registerTest_ro_qie
 from registerTest_rw import registerTest_rw_bridge
 from registerTest_rw import registerTest_rw_igloo
 from registerTest_rw import registerTest_rw_qie
@@ -39,7 +39,7 @@ def backplanereset(crate):
    cmds.append('put HB{0}-bkp_reset 0'.format(crate))
 
    output = sendCommands.send_commands(cmds=cmds, script=False, port=port, control_hub=host)   
-   
+
    for entry in output:
       result = entry['result']
       if not 'OK' in result:
@@ -134,7 +134,7 @@ if __name__ == "__main__":
       sys.exit()
 
    tempname = str(uuid.uuid4())
-   templogname = "{0}.log.tmp".format(tempname)
+   templogname = "{0}.runlog.tmp".format(tempname)
    logging.basicConfig(filename=templogname, level=logging.DEBUG)
    console = logging.StreamHandler()
    console.setLevel(logging.INFO)
@@ -142,7 +142,7 @@ if __name__ == "__main__":
    logger = logging.getLogger(__name__)
 
    logger.info("##########")
-   logger.info('your temporary test logfile: ./{0}'.format(templogname))
+   logger.info('your temporary run log: ./{0}'.format(templogname))
    logger.info(time.ctime(time.time()))
 
    logger.info('begin crate {0}, rm {1}, slot {2}'.format(crate, rm, slot))
@@ -150,7 +150,7 @@ if __name__ == "__main__":
    # log all commands
    tempcmdlogname = "{0}.cmdlog.tmp".format(tempname)
    cmdlogfile = open(tempcmdlogname, 'w+') 
-   logger.info('your temporary command logfile: ./{0}'.format(tempcmdlogname))
+   logger.info('your temporary command log: ./{0}'.format(tempcmdlogname))
 
    # reset the backplane
    #output = []
@@ -176,45 +176,59 @@ if __name__ == "__main__":
    # rename test log file to have uID in name
    runlog_fname = outputPath+"run.log"
    os.rename(templogname, runlog_fname)
-   logger.info('the temporary log file has been renamed: {0}'.format(runlog_fname))
+   logger.info('the run log file has been renamed: {0}'.format(runlog_fname))
    # rename command log file to have uID in name
-   runcmdlog_fname = outputPath+"cmds.log"
+   runcmdlog_fname = outputPath+"cmd.log"
    os.rename(tempcmdlogname, runcmdlog_fname)
-   logger.info('the temporary command log file has been renamed: {0}'.format(runcmdlog_fname))
+   logger.info('the command log file has been renamed: {0}'.format(runcmdlog_fname))
 
    # set defaults
-   output = registerTest_setDefaults_bridge(crate, rm, slot)
+   output, pass_setDefaults_bridge = registerTest_setDefaults_bridge(crate, rm, slot)
    writeToCmdLog(output, cmdlogfile)
-   output = registerTest_setDefaults_igloo(crate, rm, slot)
+   output, pass_setDefaults_igloo = registerTest_setDefaults_igloo(crate, rm, slot)
    writeToCmdLog(output, cmdlogfile)
-   output = registerTest_setDefaults_qie(crate, rm, slot)
+   output, pass_setDefaults_qie = registerTest_setDefaults_qie(crate, rm, slot)
    writeToCmdLog(output, cmdlogfile)
    
    # run bridge tests
-   output = registerTest_ro_bridge(crate, rm, slot)
+   output, pass_ro_bridge = registerTest_ro_bridge(crate, rm, slot)
    writeToCmdLog(output, cmdlogfile)
-   output = registerTest_rw_bridge(crate, rm, slot)
+   output, pass_rw_bridge = registerTest_rw_bridge(crate, rm, slot)
    writeToCmdLog(output, cmdlogfile)
-   output = registerTest_setDefaults_bridge(crate, rm, slot)
+   output, pass_setDefaults_bridge = registerTest_setDefaults_bridge(crate, rm, slot)
    writeToCmdLog(output, cmdlogfile)
    
    # run igloo tests
-   outlog = registerTest_ro_igloo(crate, rm, slot)
+   outlog, pass_ro_igloo = registerTest_ro_igloo(crate, rm, slot)
    writeToCmdLog(output, cmdlogfile)
-   output = registerTest_rw_igloo(crate, rm, slot)
+   output, pass_rw_igloo = registerTest_rw_igloo(crate, rm, slot)
    writeToCmdLog(output, cmdlogfile)
-   output = registerTest_setDefaults_igloo(crate, rm, slot)
+   output, pass_setDefaults_igloo = registerTest_setDefaults_igloo(crate, rm, slot)
    writeToCmdLog(output, cmdlogfile)
 
    # run qie tests
-   output = registerTest_ro_qie(crate, rm, slot)
+   #output, pass_ro_qie = registerTest_ro_qie(crate, rm, slot)
+   #writeToCmdLog(output, cmdlogfile)
+   output, pass_rw_qie = registerTest_rw_qie(crate, rm, slot)
    writeToCmdLog(output, cmdlogfile)
-   output = registerTest_rw_qie(crate, rm, slot)
+   output, pass_setDefaults_qie = registerTest_setDefaults_qie(crate, rm, slot)
    writeToCmdLog(output, cmdlogfile)
-   output = registerTest_setDefaults_qie(crate, rm, slot)
-   writeToCmdLog(output, cmdlogfile)
+
+   testresults = {
+      "uID" : uID,
+      "bridge_ro" : pass_ro_bridge,
+      "bridge_rw" : pass_rw_bridge,
+      "igloo_ro" : pass_ro_igloo,
+      "igloo_rw" : pass_rw_igloo,
+      "qie_rw" : pass_rw_qie
+   }
+
+   with open(outputPath+"results.log", 'w') as testresultsfile:
+      testresultsfile.write(str(testresults))
+   logger.info('the test results have been saved as {0}results.log'.format(outputPath))
 
    logger.info('finished crate {0}, rm {1}, slot {2}'.format(crate, rm, slot))
    logger.info(time.ctime(time.time()))
    logger.info("##########")
+
 

--- a/registerTest_rw.py
+++ b/registerTest_rw.py
@@ -33,25 +33,29 @@ def getRegisterSize(regs, crate, rm, slot, isBridge=False, isIgloo=False, isQIE=
          for (put, get) in zip(output[::2], output[1::2]):
             getvar = int(get['result'], 16)
             if not getvar == tempint:
-               tempstring = "register size is {0} bits. put {1}. get {2}".format(i, put, get)
-               print tempstring
+               print "register size is {0} bits. put {1}. get {2}".format(i, put, get)
                isgood = False
+               break
          if not isgood:
             break
 
 def checkOutput_rw(output):
-
+   testpass = True
    for i, (put, get) in enumerate(zip(output[::2], output[1::2])):
       if not 'OK' in put['result']:
          logger.error('trouble with put command: {0}'.format(put))
+         testpass = False
          continue
       if "ERROR" in get['result']:
          logger.error('trouble with get command: {0}'.format(get))
+         testpass = False
          continue
       putvar = ' '.join(put['cmd'].split()[2:]).replace('0x', '')
       getvar = get['result'].replace('0x', '')
       if not putvar==getvar:
          logger.error('put!=get: {0}, {1}'.format(put, get))
+         testpass = False
+   return testpass
 
 
 def registerTest_rw_bridge(crate, rm, slot):
@@ -85,9 +89,8 @@ def registerTest_rw_bridge(crate, rm, slot):
          cmds.append(getcmd)
 
    output = sendCommands.send_commands(cmds=cmds, script=False, control_hub=host, port=port)
-   checkOutput_rw(output)
-
-   return output
+   testpass = checkOutput_rw(output)
+   return output, testpass
 
 
 def registerTest_rw_igloo(crate, rm, slot):
@@ -130,9 +133,8 @@ def registerTest_rw_igloo(crate, rm, slot):
             cmds.append(getcmd)
 
    output = sendCommands.send_commands(cmds=cmds, script=False, control_hub=host, port=port)
-   checkOutput_rw(output)
-
-   return output
+   testpass = checkOutput_rw(output)
+   return output, testpass
 
 
 def registerTest_rw_qie(crate, rm, slot):
@@ -160,7 +162,7 @@ def registerTest_rw_qie(crate, rm, slot):
       ["TimingIref", 3],
       ["TimingThresholdDAC", 8],
       ["Trim", 2]
-      #["HB{0}-{1}-Qie[{2}-{3}]_ck_ph", -1]
+      #["HB{0}-{1}-Qie[{2}-{3}]_ck_ph", -1] QIE->Qie?
    ]
    #getRegisterSize(regs, crate, rm, slot, isBridge=False, isIgloo=False, isQIE=True)
 
@@ -175,9 +177,9 @@ def registerTest_rw_qie(crate, rm, slot):
             putcmd += "{0} ".format(hex(randint(0, (2**reg[1])-1)))
          cmds.append(putcmd)
          cmds.append(getcmd)      
-   output = sendCommands.send_commands(cmds=cmds, script=False, control_hub=host, port=port)
-   checkOutput_rw(output)
 
-   return output
+   output = sendCommands.send_commands(cmds=cmds, script=False, control_hub=host, port=port)
+   testpass = checkOutput_rw(output)
+   return output, testpass
 
 

--- a/registerTest_setDefaults.py
+++ b/registerTest_setDefaults.py
@@ -8,9 +8,12 @@ host = 'localhost'
 
 
 def checkOutput_setDefaults(output):
+   testpass = True
    for entry in output:
       if not 'OK' in entry['result']:
          logger.warning('trouble with put command: {0}'.format(entry))
+         testpass = False
+   return testpass
 
 
 def registerTest_setDefaults_bridge(crate, rm, slot):
@@ -38,9 +41,8 @@ def registerTest_setDefaults_bridge(crate, rm, slot):
       cmds.append("put HB{0}-{1}-{2}-{3} {4}".format(crate, rm, slot, reg[0], reg[1]))
 
    output = sendCommands.send_commands(cmds=cmds, script=True, port=port, control_hub=host)
-   checkOutput_setDefaults(output)
-   
-   return output
+   testpass = checkOutput_setDefaults(output)
+   return output, testpass
 
 
 def registerTest_setDefaults_igloo(crate, rm, slot):
@@ -76,9 +78,8 @@ def registerTest_setDefaults_igloo(crate, rm, slot):
          cmds.append("put HB{0}-{1}-{2}-{3}_{4} {5}".format(crate, rm, slot, igloo, reg[0], reg[1])  )
 
    output = sendCommands.send_commands(cmds=cmds, script=True, port=port, control_hub=host)
-   checkOutput_setDefaults(output)
-
-   return output
+   testpass = checkOutput_setDefaults(output)
+   return output, testpass
 
 
 def registerTest_setDefaults_qie(crate, rm, slot):
@@ -114,9 +115,9 @@ def registerTest_setDefaults_qie(crate, rm, slot):
    cmds = []
    for reg in regs:
       cmds.append("put HB{0}-{1}-QIE[{2}-{3}]_{4} 16*{5}".format(crate, rm, QIEstart, QIEend, reg[0], reg[1]))
+
    output = sendCommands.send_commands(cmds=cmds, script=True, port=port, control_hub=host)
-  
-   checkOutput_setDefaults(output)
-   return output
+   testpass = checkOutput_setDefaults(output)
+   return output, testpass
 
 


### PR DESCRIPTION
1) implement correct output decoding (checking the ro values are correct) for the read-only tests. (It was just error checking before, i needed to update things to accompany (Danny's suggestion of) speed upgrades.
2) produce the dictionary output file necessary for reporting test results to the database.